### PR TITLE
Fix stale package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-todo",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -60,13 +60,11 @@
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
         "json-stable-stringify": "1.0.1"
       }
     },
@@ -151,6 +149,14 @@
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
       }
     },
     "arr-diff": {
@@ -206,6 +212,11 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -215,7 +226,6 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.8",
         "inherits": "2.0.3",
@@ -237,12 +247,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
@@ -267,7 +274,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000747",
+        "caniuse-db": "1.0.30000748",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -331,6 +338,15 @@
         "source-map": "0.5.7"
       },
       "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1001,8 +1017,8 @@
           "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000747",
-            "electron-to-chromium": "1.3.26"
+            "caniuse-lite": "1.0.30000748",
+            "electron-to-chromium": "1.3.27"
           }
         }
       }
@@ -1110,11 +1126,21 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
+      "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
+    },
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -1130,11 +1156,43 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
+    "bigi": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
+      "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
+    },
     "binary-extensions": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "bitcoinjs-lib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-2.3.0.tgz",
+      "integrity": "sha1-+k0nuWlkFdWzA1furF0iJxPhlmo=",
+      "requires": {
+        "bigi": "1.4.2",
+        "bip66": "1.1.5",
+        "bs58check": "1.3.4",
+        "buffer-compare": "1.1.1",
+        "buffer-equals": "1.0.4",
+        "buffer-reverse": "1.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ecurve": "1.0.5",
+        "randombytes": "2.0.5",
+        "typeforce": "1.11.5",
+        "wif": "2.0.6"
+      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -1146,6 +1204,8 @@
     },
     "blockstack": {
       "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-0.11.1.tgz",
+      "integrity": "sha512-PlgOeOSqbqRmUdTADMffrsFYVIOcgIrUlKe1+6mp8hf+Cm7SQPMBfH7yfMu1Z0eDIInKTUy0MWL+ePC7Ge3AeQ==",
       "requires": {
         "ajv": "4.11.8",
         "bigi": "1.4.2",
@@ -1168,7871 +1228,19 @@
         "uuid": "3.1.0",
         "validator": "7.2.0",
         "zone-file": "0.2.2"
-      },
-      "dependencies": {
-        "JSONStream": {
-          "bundled": true
-        },
-        "accepts": {
-          "version": "1.3.4",
-          "bundled": true,
-          "requires": {
-            "mime-types": "2.1.17",
-            "negotiator": "0.6.1"
-          }
-        },
-        "acorn": {
-          "bundled": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          },
-          "dependencies": {
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "ansi-html": {
-          "version": "0.0.7",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "bundled": true
-        },
-        "ansi-styles": {
-          "bundled": true
-        },
-        "anymatch": {
-          "bundled": true
-        },
-        "argparse": {
-          "bundled": true
-        },
-        "arr-diff": {
-          "bundled": true
-        },
-        "arr-flatten": {
-          "bundled": true
-        },
-        "array-flatten": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "array-iterate": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "array-unique": {
-          "bundled": true
-        },
-        "arrify": {
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "async-each": {
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "babel-cli": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-core": "6.26.0",
-            "babel-polyfill": "6.26.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "chokidar": "1.7.0",
-            "commander": "2.11.0",
-            "convert-source-map": "1.5.0",
-            "fs-readdir-recursive": "1.0.0",
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "output-file-sync": "1.1.2",
-            "path-is-absolute": "1.0.1",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "v8flags": "2.1.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "anymatch": {
-              "version": "1.3.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
-              }
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "arr-flatten": "1.1.0"
-              }
-            },
-            "arr-flatten": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true,
-              "optional": true
-            },
-            "async-each": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "babel-code-frame": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-              }
-            },
-            "babel-core": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.0",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.0",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.4",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.7",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
-              }
-            },
-            "babel-generator": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.4",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
-              }
-            },
-            "babel-helpers": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-              }
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-register": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-core": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.1",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.4",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
-              }
-            },
-            "babel-template": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-types": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
-              }
-            },
-            "babylon": {
-              "version": "6.18.0",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "binary-extensions": {
-              "version": "1.10.0",
-              "bundled": true,
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "chokidar": {
-              "version": "1.7.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.1.2",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "convert-source-map": {
-              "version": "1.5.0",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "2.5.1",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "detect-indent": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "repeating": "2.0.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fill-range": "2.2.3"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "fill-range": {
-              "version": "2.2.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
-              }
-            },
-            "for-in": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "for-own": {
-              "version": "0.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "for-in": "1.0.2"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-glob": "2.0.1"
-              }
-            },
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true,
-              "optional": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "home-or-tmp": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "binary-extensions": "1.10.0"
-              }
-            },
-            "is-buffer": {
-              "version": "1.1.5",
-              "bundled": true
-            },
-            "is-dotfile": {
-              "version": "1.0.3",
-              "bundled": true,
-              "optional": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-finite": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsesc": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "json5": {
-              "version": "0.5.1",
-              "bundled": true
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "1.1.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "private": {
-              "version": "0.1.7",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true,
-              "optional": true
-            },
-            "randomatic": {
-              "version": "1.1.7",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-              },
-              "dependencies": {
-                "is-number": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "is-buffer": "1.1.5"
-                      }
-                    }
-                  }
-                },
-                "kind-of": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "readdirp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.3",
-                "set-immediate-shim": "1.0.1"
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.11.0",
-              "bundled": true
-            },
-            "regex-cache": {
-              "version": "0.4.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "is-equal-shallow": "0.1.3"
-              }
-            },
-            "remove-trailing-separator": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "repeat-element": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "repeat-string": {
-              "version": "1.6.1",
-              "bundled": true,
-              "optional": true
-            },
-            "repeating": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-finite": "1.0.2"
-              }
-            },
-            "set-immediate-shim": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true
-            },
-            "source-map-support": {
-              "version": "0.4.18",
-              "bundled": true,
-              "requires": {
-                "source-map": "0.5.7"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "babel-code-frame": {
-          "bundled": true
-        },
-        "babel-core": {
-          "bundled": true
-        },
-        "babel-eslint": {
-          "version": "6.1.2",
-          "bundled": true,
-          "requires": {
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash.assign": "4.2.0",
-            "lodash.pickby": "4.6.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "babel-code-frame": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-              }
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-types": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
-              }
-            },
-            "babylon": {
-              "version": "6.18.0",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "core-js": {
-              "version": "2.5.1",
-              "bundled": true
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.assign": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "lodash.pickby": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "regenerator-runtime": {
-              "version": "0.11.0",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "babel-generator": {
-          "bundled": true
-        },
-        "babel-helper-bindify-decorators": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-explode-assignable-expression": "6.24.1"
-          }
-        },
-        "babel-helper-builder-react-jsx": {
-          "version": "6.26.0",
-          "bundled": true
-        },
-        "babel-helper-explode-assignable-expression": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helper-explode-class": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-bindify-decorators": "6.24.1"
-          }
-        },
-        "babel-helper-function-name": {
-          "bundled": true
-        },
-        "babel-helper-get-function-arity": {
-          "bundled": true
-        },
-        "babel-helper-remap-async-to-generator": {
-          "version": "6.24.1",
-          "bundled": true
-        },
-        "babel-helpers": {
-          "bundled": true
-        },
-        "babel-messages": {
-          "bundled": true
-        },
-        "babel-plugin-syntax-async-functions": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-async-generators": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-class-constructor-call": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-class-properties": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-decorators": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-do-expressions": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-dynamic-import": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-export-extensions": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-flow": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-function-bind": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-jsx": {
-          "version": "6.18.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-          "version": "6.13.0",
-          "bundled": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-          "version": "6.22.0",
-          "bundled": true
-        },
-        "babel-plugin-system-import-transformer": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-dynamic-import": "6.18.0"
-          }
-        },
-        "babel-plugin-transform-async-generator-functions": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-generators": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-async-to-generator": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-functions": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-class-constructor-call": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-class-constructor-call": "6.18.0"
-          }
-        },
-        "babel-plugin-transform-class-properties": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-class-properties": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-decorators": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-explode-class": "6.24.1",
-            "babel-plugin-syntax-decorators": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-decorators-legacy": {
-          "version": "1.3.4",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-decorators": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-do-expressions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-do-expressions": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-export-extensions": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-export-extensions": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-flow-strip-types": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-flow": "6.18.0"
-          }
-        },
-        "babel-plugin-transform-function-bind": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-function-bind": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-object-rest-spread": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-object-rest-spread": "6.13.0"
-          }
-        },
-        "babel-plugin-transform-react-display-name": {
-          "version": "6.25.0",
-          "bundled": true
-        },
-        "babel-plugin-transform-react-jsx": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-helper-builder-react-jsx": "6.26.0",
-            "babel-plugin-syntax-jsx": "6.18.0"
-          }
-        },
-        "babel-plugin-transform-react-jsx-self": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-jsx": "6.18.0"
-          }
-        },
-        "babel-plugin-transform-react-jsx-source": {
-          "version": "6.22.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-jsx": "6.18.0"
-          }
-        },
-        "babel-polyfill": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.10.5"
-          },
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
-              },
-              "dependencies": {
-                "regenerator-runtime": {
-                  "version": "0.11.0",
-                  "bundled": true
-                }
-              }
-            },
-            "core-js": {
-              "version": "2.5.1",
-              "bundled": true
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true
-            }
-          }
-        },
-        "babel-preset-es2015": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-            "babel-plugin-transform-es2015-object-super": "6.24.1",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-            "babel-plugin-transform-regenerator": "6.26.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "babel-code-frame": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-              }
-            },
-            "babel-helper-call-delegate": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-helper-define-map": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-helper-function-name": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-helper-get-function-arity": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-helper-hoist-variables": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-helper-optimise-call-expression": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-helper-regex": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-helper-replace-supers": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-check-es2015-constants": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-arrow-functions": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-block-scoped-functions": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-block-scoping": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-plugin-transform-es2015-classes": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-computed-properties": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-destructuring": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-duplicate-keys": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-for-of": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-function-name": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-literals": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-modules-amd": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-modules-commonjs": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-modules-systemjs": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-modules-umd": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-object-super": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-parameters": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-shorthand-properties": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-spread": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-sticky-regex": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-template-literals": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-typeof-symbol": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-plugin-transform-es2015-unicode-regex": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
-              }
-            },
-            "babel-plugin-transform-regenerator": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "regenerator-transform": "0.10.1"
-              }
-            },
-            "babel-plugin-transform-strict-mode": {
-              "version": "6.24.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
-              }
-            },
-            "babel-template": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-types": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
-              }
-            },
-            "babylon": {
-              "version": "6.18.0",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "core-js": {
-              "version": "2.5.1",
-              "bundled": true
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsesc": {
-              "version": "0.5.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "private": {
-              "version": "0.1.7",
-              "bundled": true
-            },
-            "regenerate": {
-              "version": "1.3.3",
-              "bundled": true
-            },
-            "regenerator-runtime": {
-              "version": "0.11.0",
-              "bundled": true
-            },
-            "regenerator-transform": {
-              "version": "0.10.1",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.7"
-              }
-            },
-            "regexpu-core": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
-              }
-            },
-            "regjsgen": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "regjsparser": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "jsesc": "0.5.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "babel-preset-flow": {
-          "version": "6.23.0",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-transform-flow-strip-types": "6.22.0"
-          }
-        },
-        "babel-preset-react": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-jsx": "6.18.0",
-            "babel-plugin-transform-react-display-name": "6.25.0",
-            "babel-plugin-transform-react-jsx": "6.24.1",
-            "babel-plugin-transform-react-jsx-self": "6.22.0",
-            "babel-plugin-transform-react-jsx-source": "6.22.0",
-            "babel-preset-flow": "6.23.0"
-          }
-        },
-        "babel-preset-stage-0": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-transform-do-expressions": "6.22.0",
-            "babel-plugin-transform-function-bind": "6.22.0",
-            "babel-preset-stage-1": "6.24.1"
-          }
-        },
-        "babel-preset-stage-1": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-transform-class-constructor-call": "6.24.1",
-            "babel-plugin-transform-export-extensions": "6.22.0",
-            "babel-preset-stage-2": "6.24.1"
-          }
-        },
-        "babel-preset-stage-2": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-dynamic-import": "6.18.0",
-            "babel-plugin-transform-class-properties": "6.24.1",
-            "babel-plugin-transform-decorators": "6.24.1",
-            "babel-preset-stage-3": "6.24.1"
-          }
-        },
-        "babel-preset-stage-3": {
-          "version": "6.24.1",
-          "bundled": true,
-          "requires": {
-            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-            "babel-plugin-transform-async-generator-functions": "6.24.1",
-            "babel-plugin-transform-async-to-generator": "6.24.1",
-            "babel-plugin-transform-exponentiation-operator": "6.24.1",
-            "babel-plugin-transform-object-rest-spread": "6.26.0"
-          }
-        },
-        "babel-register": {
-          "bundled": true
-        },
-        "babel-runtime": {
-          "bundled": true
-        },
-        "babel-template": {
-          "bundled": true
-        },
-        "babel-traverse": {
-          "bundled": true
-        },
-        "babel-types": {
-          "bundled": true
-        },
-        "babelify": {
-          "version": "7.3.0",
-          "bundled": true
-        },
-        "babylon": {
-          "bundled": true
-        },
-        "bail": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "balanced-match": {
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "bigi": {
-          "version": "1.4.2",
-          "bundled": true
-        },
-        "binary-extensions": {
-          "bundled": true
-        },
-        "bitcoinjs-lib": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "bigi": "1.4.2",
-            "bip66": "1.1.5",
-            "bs58check": "1.3.4",
-            "buffer-compare": "1.1.1",
-            "buffer-equals": "1.0.4",
-            "buffer-reverse": "1.0.1",
-            "create-hash": "1.1.3",
-            "create-hmac": "1.1.6",
-            "ecurve": "1.0.5",
-            "randombytes": "2.0.5",
-            "typeforce": "1.11.5",
-            "wif": "2.0.6"
-          },
-          "dependencies": {
-            "base-x": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "bip66": {
-              "version": "1.1.5",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "bs58": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "base-x": "1.1.0"
-              }
-            },
-            "bs58check": {
-              "version": "1.3.4",
-              "bundled": true,
-              "requires": {
-                "bs58": "3.1.0",
-                "create-hash": "1.1.3"
-              }
-            },
-            "buffer-compare": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "buffer-equals": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "buffer-reverse": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "cipher-base": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "create-hash": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "sha.js": "2.4.9"
-              }
-            },
-            "create-hmac": {
-              "version": "1.1.6",
-              "bundled": true,
-              "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.9"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "randombytes": {
-              "version": "2.0.5",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "ripemd160": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "hash-base": "2.0.2",
-                "inherits": "2.0.3"
-              }
-            },
-            "sha.js": {
-              "version": "2.4.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "typeforce": {
-              "version": "1.11.5",
-              "bundled": true
-            },
-            "wif": {
-              "version": "2.0.6",
-              "bundled": true,
-              "requires": {
-                "bs58check": "1.3.4"
-              }
-            }
-          }
-        },
-        "blockstack-storage": {
-          "version": "0.2.11",
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "bitcoinjs-lib": "2.3.0",
-            "elliptic": "6.4.0",
-            "isomorphic-fetch": "2.2.1",
-            "jsontokens": "0.7.6",
-            "uuid": "3.1.0"
-          }
-        },
-        "blue-tape": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "tape": "4.8.0"
-          }
-        },
-        "body": {
-          "version": "5.1.0",
-          "bundled": true,
-          "requires": {
-            "continuable-cache": "0.3.1",
-            "error": "7.0.2",
-            "raw-body": "1.1.7",
-            "safe-json-parse": "1.0.1"
-          }
-        },
-        "body-parser": {
-          "version": "1.18.2",
-          "bundled": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "1.0.4",
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "http-errors": "1.6.2",
-            "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
-            "qs": "6.5.1",
-            "raw-body": "2.3.2",
-            "type-is": "1.6.15"
-          },
-          "dependencies": {
-            "bytes": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "raw-body": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "bytes": "3.0.0",
-                "http-errors": "1.6.2",
-                "iconv-lite": "0.4.19",
-                "unpipe": "1.0.0"
-              }
-            }
-          }
-        },
-        "boolbase": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "brace-expansion": {
-          "bundled": true
-        },
-        "braces": {
-          "bundled": true
-        },
-        "browser-resolve": {
-          "bundled": true
-        },
-        "browserify": {
-          "version": "13.3.0",
-          "bundled": true,
-          "requires": {
-            "JSONStream": "1.3.1",
-            "assert": "1.4.1",
-            "browser-pack": "6.0.2",
-            "browser-resolve": "1.11.2",
-            "browserify-zlib": "0.1.4",
-            "buffer": "4.9.1",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.5.2",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.11.1",
-            "defined": "1.0.0",
-            "deps-sort": "2.0.0",
-            "domain-browser": "1.1.7",
-            "duplexer2": "0.1.4",
-            "events": "1.1.1",
-            "glob": "7.1.2",
-            "has": "1.0.1",
-            "htmlescape": "1.1.1",
-            "https-browserify": "0.0.1",
-            "inherits": "2.0.3",
-            "insert-module-globals": "7.0.1",
-            "labeled-stream-splicer": "2.0.0",
-            "module-deps": "4.1.1",
-            "os-browserify": "0.1.2",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.0",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "read-only-stream": "2.0.0",
-            "readable-stream": "2.3.3",
-            "resolve": "1.4.0",
-            "shasum": "1.0.2",
-            "shell-quote": "1.6.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.7.2",
-            "string_decoder": "0.10.31",
-            "subarg": "1.0.0",
-            "syntax-error": "1.3.0",
-            "through2": "2.0.3",
-            "timers-browserify": "1.4.2",
-            "tty-browserify": "0.0.0",
-            "url": "0.11.0",
-            "util": "0.10.3",
-            "vm-browserify": "0.0.4",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "JSONStream": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
-              }
-            },
-            "acorn": {
-              "version": "4.0.13",
-              "bundled": true
-            },
-            "array-filter": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "array-map": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "array-reduce": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "asn1.js": {
-              "version": "4.9.1",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
-              }
-            },
-            "assert": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "util": "0.10.3"
-              }
-            },
-            "astw": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "4.0.13"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "base64-js": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "bn.js": {
-              "version": "4.11.8",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "brorand": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "browser-pack": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "JSONStream": "1.3.1",
-                "combine-source-map": "0.7.2",
-                "defined": "1.0.0",
-                "through2": "2.0.3",
-                "umd": "3.0.1"
-              }
-            },
-            "browser-resolve": {
-              "version": "1.11.2",
-              "bundled": true,
-              "requires": {
-                "resolve": "1.1.7"
-              },
-              "dependencies": {
-                "resolve": {
-                  "version": "1.1.7",
-                  "bundled": true
-                }
-              }
-            },
-            "browserify-aes": {
-              "version": "1.0.8",
-              "bundled": true,
-              "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "browserify-cipher": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "browserify-aes": "1.0.8",
-                "browserify-des": "1.0.0",
-                "evp_bytestokey": "1.0.3"
-              }
-            },
-            "browserify-des": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
-              }
-            },
-            "browserify-rsa": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.5"
-              }
-            },
-            "browserify-sign": {
-              "version": "4.0.4",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.0"
-              }
-            },
-            "browserify-zlib": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "pako": "0.2.9"
-              }
-            },
-            "buffer": {
-              "version": "4.9.1",
-              "bundled": true,
-              "requires": {
-                "base64-js": "1.2.1",
-                "ieee754": "1.1.8",
-                "isarray": "1.0.0"
-              }
-            },
-            "buffer-xor": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "builtin-status-codes": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "cached-path-relative": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "cipher-base": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "combine-source-map": {
-              "version": "0.7.2",
-              "bundled": true,
-              "requires": {
-                "convert-source-map": "1.1.3",
-                "inline-source-map": "0.6.2",
-                "lodash.memoize": "3.0.4",
-                "source-map": "0.5.7"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "concat-stream": {
-              "version": "1.5.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  }
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "date-now": "0.1.4"
-              }
-            },
-            "constants-browserify": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "convert-source-map": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "create-ecdh": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
-              }
-            },
-            "create-hash": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "sha.js": "2.4.9"
-              }
-            },
-            "create-hmac": {
-              "version": "1.1.6",
-              "bundled": true,
-              "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.9"
-              }
-            },
-            "crypto-browserify": {
-              "version": "3.11.1",
-              "bundled": true,
-              "requires": {
-                "browserify-cipher": "1.0.0",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.0",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "diffie-hellman": "5.0.2",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
-                "public-encrypt": "4.0.0",
-                "randombytes": "2.0.5"
-              }
-            },
-            "date-now": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "defined": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "deps-sort": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "JSONStream": "1.3.1",
-                "shasum": "1.0.2",
-                "subarg": "1.0.0",
-                "through2": "2.0.3"
-              }
-            },
-            "des.js": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
-              }
-            },
-            "detective": {
-              "version": "4.5.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "4.0.13",
-                "defined": "1.0.0"
-              }
-            },
-            "diffie-hellman": {
-              "version": "5.0.2",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.5"
-              }
-            },
-            "domain-browser": {
-              "version": "1.1.7",
-              "bundled": true
-            },
-            "duplexer2": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3"
-              }
-            },
-            "events": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "evp_bytestokey": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "function-bind": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "has": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "function-bind": "1.1.1"
-              }
-            },
-            "htmlescape": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "https-browserify": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "ieee754": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "indexof": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "inline-source-map": {
-              "version": "0.6.2",
-              "bundled": true,
-              "requires": {
-                "source-map": "0.5.7"
-              }
-            },
-            "insert-module-globals": {
-              "version": "7.0.1",
-              "bundled": true,
-              "requires": {
-                "JSONStream": "1.3.1",
-                "combine-source-map": "0.7.2",
-                "concat-stream": "1.5.2",
-                "is-buffer": "1.1.5",
-                "lexical-scope": "1.2.0",
-                "process": "0.11.10",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
-              }
-            },
-            "is-buffer": {
-              "version": "1.1.5",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "0.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "labeled-stream-splicer": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "stream-splicer": "2.0.0"
-              },
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "lexical-scope": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "astw": "2.2.0"
-              }
-            },
-            "lodash.memoize": {
-              "version": "3.0.4",
-              "bundled": true
-            },
-            "miller-rabin": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
-              }
-            },
-            "minimalistic-assert": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "module-deps": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "JSONStream": "1.3.1",
-                "browser-resolve": "1.11.2",
-                "cached-path-relative": "1.0.1",
-                "concat-stream": "1.5.2",
-                "defined": "1.0.0",
-                "detective": "4.5.0",
-                "duplexer2": "0.1.4",
-                "inherits": "2.0.3",
-                "parents": "1.0.1",
-                "readable-stream": "2.3.3",
-                "resolve": "1.4.0",
-                "stream-combiner2": "1.1.1",
-                "subarg": "1.0.0",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-browserify": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "pako": {
-              "version": "0.2.9",
-              "bundled": true
-            },
-            "parents": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "path-platform": "0.11.15"
-              }
-            },
-            "parse-asn1": {
-              "version": "5.1.0",
-              "bundled": true,
-              "requires": {
-                "asn1.js": "4.9.1",
-                "browserify-aes": "1.0.8",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
-              }
-            },
-            "path-browserify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-platform": {
-              "version": "0.11.15",
-              "bundled": true
-            },
-            "pbkdf2": {
-              "version": "3.0.14",
-              "bundled": true,
-              "requires": {
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.9"
-              }
-            },
-            "process": {
-              "version": "0.11.10",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "public-encrypt": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "parse-asn1": "5.1.0",
-                "randombytes": "2.0.5"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "querystring": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "querystring-es3": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "randombytes": {
-              "version": "2.0.5",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "read-only-stream": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              },
-              "dependencies": {
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "path-parse": "1.0.5"
-              }
-            },
-            "ripemd160": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "hash-base": "2.0.2",
-                "inherits": "2.0.3"
-              }
-            },
-            "sha.js": {
-              "version": "2.4.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "shasum": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "json-stable-stringify": "0.0.1",
-                "sha.js": "2.4.9"
-              }
-            },
-            "shell-quote": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true
-            },
-            "stream-browserify": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "stream-combiner2": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "duplexer2": "0.1.4",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "stream-http": {
-              "version": "2.7.2",
-              "bundled": true,
-              "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
-              }
-            },
-            "stream-splicer": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true
-            },
-            "subarg": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "minimist": "1.2.0"
-              }
-            },
-            "syntax-error": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "4.0.13"
-              }
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
-              }
-            },
-            "timers-browserify": {
-              "version": "1.4.2",
-              "bundled": true,
-              "requires": {
-                "process": "0.11.10"
-              }
-            },
-            "to-arraybuffer": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "tty-browserify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "bundled": true
-            },
-            "umd": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "url": {
-              "version": "0.11.0",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.3.2",
-                "querystring": "0.2.0"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "bundled": true
-                }
-              }
-            },
-            "util": {
-              "version": "0.10.3",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.1"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "vm-browserify": {
-              "version": "0.0.4",
-              "bundled": true,
-              "requires": {
-                "indexof": "0.0.1"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "buffer-shims": {
-          "bundled": true
-        },
-        "builtin-modules": {
-          "bundled": true
-        },
-        "bytes": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "ccount": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "chalk": {
-          "bundled": true
-        },
-        "character-entities": {
-          "version": "1.2.1",
-          "bundled": true
-        },
-        "character-entities-html4": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "character-entities-legacy": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "character-reference-invalid": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "cheerio": {
-          "version": "0.22.0",
-          "bundled": true,
-          "requires": {
-            "css-select": "1.2.0",
-            "dom-serializer": "0.1.0",
-            "entities": "1.1.1",
-            "htmlparser2": "3.9.2",
-            "lodash.assignin": "4.2.0",
-            "lodash.bind": "4.2.1",
-            "lodash.defaults": "4.2.0",
-            "lodash.filter": "4.6.0",
-            "lodash.flatten": "4.4.0",
-            "lodash.foreach": "4.5.0",
-            "lodash.map": "4.6.0",
-            "lodash.merge": "4.6.0",
-            "lodash.pick": "4.4.0",
-            "lodash.reduce": "4.6.0",
-            "lodash.reject": "4.6.0",
-            "lodash.some": "4.6.0"
-          }
-        },
-        "chokidar": {
-          "bundled": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "clone": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "clone-buffer": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "cloneable-readable": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "code-point-at": {
-          "bundled": true
-        },
-        "collapse-white-space": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "comma-separated-tokens": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "trim": "0.0.1"
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "bundled": true
-        },
-        "concat-stream": {
-          "bundled": true,
-          "dependencies": {
-            "readable-stream": {
-              "bundled": true
-            },
-            "string_decoder": {
-              "bundled": true
-            }
-          }
-        },
-        "content-disposition": {
-          "version": "0.5.2",
-          "bundled": true
-        },
-        "content-type": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "continuable-cache": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "convert-source-map": {
-          "bundled": true
-        },
-        "cookie": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "cookie-signature": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "core-js": {
-          "bundled": true
-        },
-        "core-util-is": {
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "crypto": {
-          "version": "0.0.3",
-          "bundled": true
-        },
-        "css-select": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "boolbase": "1.0.0",
-            "css-what": "2.1.0",
-            "domutils": "1.5.1",
-            "nth-check": "1.0.1"
-          }
-        },
-        "css-what": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "custom-protocol-detection-blockstack": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "debug": {
-          "bundled": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "deep-equal": {
-          "version": "0.2.2",
-          "bundled": true
-        },
-        "defined": {
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "depd": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "destroy": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "detab": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "detect-indent": {
-          "bundled": true
-        },
-        "detective": {
-          "bundled": true
-        },
-        "diff": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "disparity": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "diff": "1.4.0"
-          }
-        },
-        "doctrine-temporary-fork": {
-          "version": "2.0.0-alpha-allowarrayindex",
-          "bundled": true
-        },
-        "documentation": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-html": "0.0.7",
-            "babel-plugin-system-import-transformer": "3.1.0",
-            "babel-plugin-transform-decorators-legacy": "1.3.4",
-            "babel-preset-es2015": "6.24.1",
-            "babel-preset-react": "6.24.1",
-            "babel-preset-stage-0": "6.24.1",
-            "babelify": "7.3.0",
-            "disparity": "2.0.0",
-            "doctrine-temporary-fork": "2.0.0-alpha-allowarrayindex",
-            "get-comments": "1.0.1",
-            "get-port": "3.2.0",
-            "git-url-parse": "6.2.2",
-            "github-slugger": "1.1.3",
-            "globals-docs": "2.3.0",
-            "highlight.js": "9.12.0",
-            "mdast-util-inject": "1.1.0",
-            "module-deps-sortable": "4.0.6",
-            "parse-filepath": "1.0.1",
-            "read-pkg-up": "2.0.0",
-            "remark": "8.0.0",
-            "remark-html": "6.0.1",
-            "remark-toc": "4.0.1",
-            "remote-origin-url": "0.4.0",
-            "stream-array": "1.1.2",
-            "tiny-lr": "1.0.5",
-            "unist-builder": "1.0.2",
-            "unist-util-visit": "1.1.3",
-            "vfile": "2.2.0",
-            "vfile-reporter": "4.0.0",
-            "vfile-sort": "2.1.0",
-            "vinyl": "2.1.0",
-            "vinyl-fs": "2.4.4",
-            "yargs": "6.6.0"
-          },
-          "dependencies": {
-            "module-deps-sortable": {
-              "version": "4.0.6",
-              "bundled": true
-            }
-          }
-        },
-        "dom-serializer": {
-          "version": "0.1.0",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "1.1.3",
-            "entities": "1.1.1"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "1.1.3",
-              "bundled": true
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "domhandler": {
-          "version": "2.4.1",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "bundled": true,
-          "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
-          }
-        },
-        "duplexer2": {
-          "bundled": true
-        },
-        "duplexify": {
-          "version": "3.5.1",
-          "bundled": true,
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "stream-shift": "1.0.0"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "ecurve": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "bigi": "1.4.2"
-          }
-        },
-        "ee-first": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "elliptic": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "bn.js": "4.11.8",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.3",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0",
-            "minimalistic-crypto-utils": "1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "bundled": true
-            },
-            "brorand": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "hash.js": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
-              }
-            },
-            "hmac-drbg": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "minimalistic-assert": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimalistic-crypto-utils": {
-              "version": "1.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "emoji-regex": {
-          "version": "6.1.1",
-          "bundled": true
-        },
-        "encodeurl": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "error": {
-          "version": "7.0.2",
-          "bundled": true,
-          "requires": {
-            "string-template": "0.2.1"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "es6-promise": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "escape-string-regexp": {
-          "bundled": true
-        },
-        "eslint": {
-          "version": "2.13.1",
-          "bundled": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.9",
-            "doctrine": "1.5.0",
-            "es6-map": "0.1.5",
-            "escope": "3.6.0",
-            "espree": "3.5.1",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.5",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.16.1",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.10.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "optionator": "0.8.2",
-            "path-is-absolute": "1.0.1",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.6.1",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "acorn-jsx": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "acorn": "3.3.0"
-              },
-              "dependencies": {
-                "acorn": {
-                  "version": "3.3.0",
-                  "bundled": true
-                }
-              }
-            },
-            "ajv-keywords": {
-              "version": "1.5.1",
-              "bundled": true
-            },
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "argparse": {
-              "version": "1.0.9",
-              "bundled": true,
-              "requires": {
-                "sprintf-js": "1.0.3"
-              }
-            },
-            "array-union": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "array-uniq": "1.0.3"
-              }
-            },
-            "array-uniq": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "caller-path": {
-              "version": "0.1.0",
-              "bundled": true,
-              "requires": {
-                "callsites": "0.2.0"
-              }
-            },
-            "callsites": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "circular-json": {
-              "version": "0.3.3",
-              "bundled": true
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "restore-cursor": "1.0.1"
-              }
-            },
-            "cli-width": {
-              "version": "2.2.0",
-              "bundled": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "concat-stream": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
-              }
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "d": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "es5-ext": "0.10.31"
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "del": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "doctrine": {
-              "version": "1.5.0",
-              "bundled": true,
-              "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
-              }
-            },
-            "es5-ext": {
-              "version": "0.10.31",
-              "bundled": true,
-              "requires": {
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1"
-              }
-            },
-            "es6-iterator": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-symbol": "3.1.1"
-              }
-            },
-            "es6-map": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-iterator": "2.0.1",
-                "es6-set": "0.1.5",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-              }
-            },
-            "es6-set": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-              }
-            },
-            "es6-symbol": {
-              "version": "3.1.1",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31"
-              }
-            },
-            "es6-weak-map": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "escope": {
-              "version": "3.6.0",
-              "bundled": true,
-              "requires": {
-                "es6-map": "0.1.5",
-                "es6-weak-map": "2.0.2",
-                "esrecurse": "4.2.0",
-                "estraverse": "4.2.0"
-              }
-            },
-            "espree": {
-              "version": "3.5.1",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.1.2",
-                "acorn-jsx": "3.0.1"
-              }
-            },
-            "esprima": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "esrecurse": {
-              "version": "4.2.0",
-              "bundled": true,
-              "requires": {
-                "estraverse": "4.2.0",
-                "object-assign": "4.1.1"
-              }
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "event-emitter": {
-              "version": "0.3.5",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31"
-              }
-            },
-            "exit-hook": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "figures": {
-              "version": "1.7.0",
-              "bundled": true,
-              "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
-              }
-            },
-            "file-entry-cache": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
-              }
-            },
-            "flat-cache": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "generate-function": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "is-property": "1.0.2"
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            },
-            "globby": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "ignore": {
-              "version": "3.3.5",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "inquirer": {
-              "version": "0.12.0",
-              "bundled": true,
-              "requires": {
-                "ansi-escapes": "1.4.0",
-                "ansi-regex": "2.1.1",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.2.0",
-                "figures": "1.7.0",
-                "lodash": "4.17.4",
-                "readline2": "1.0.1",
-                "run-async": "0.1.0",
-                "rx-lite": "3.1.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.16.1",
-              "bundled": true,
-              "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
-              }
-            },
-            "is-path-cwd": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-path-in-cwd": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "is-path-inside": "1.0.0"
-              }
-            },
-            "is-path-inside": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "path-is-inside": "1.0.2"
-              }
-            },
-            "is-property": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "is-resolvable": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "tryit": "1.0.3"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "js-yaml": {
-              "version": "3.10.0",
-              "bundled": true,
-              "requires": {
-                "argparse": "1.0.9",
-                "esprima": "4.0.0"
-              }
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsonpointer": {
-              "version": "4.0.1",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "mute-stream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "onetime": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            },
-            "pluralize": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "progress": {
-              "version": "1.1.8",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "mute-stream": "0.0.5"
-              }
-            },
-            "require-uncached": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
-              }
-            },
-            "resolve-from": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "restore-cursor": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0"
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "slice-ansi": {
-              "version": "0.0.4",
-              "bundled": true
-            },
-            "sprintf-js": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "table": {
-              "version": "3.8.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "ajv-keywords": "1.5.1",
-                "chalk": "1.1.3",
-                "lodash": "4.17.4",
-                "slice-ansi": "0.0.4",
-                "string-width": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  }
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "3.0.0"
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            },
-            "tryit": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "bundled": true
-            },
-            "user-home": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "1.0.2"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write": {
-              "version": "0.2.1",
-              "bundled": true,
-              "requires": {
-                "mkdirp": "0.5.1"
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-config-airbnb": {
-          "version": "9.0.1",
-          "bundled": true,
-          "requires": {
-            "eslint-config-airbnb-base": "3.0.1"
-          },
-          "dependencies": {
-            "eslint-config-airbnb-base": {
-              "version": "3.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-plugin-import": {
-          "version": "1.16.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "1.1.1",
-            "contains-path": "0.1.0",
-            "debug": "2.6.9",
-            "doctrine": "1.3.0",
-            "es6-map": "0.1.5",
-            "es6-set": "0.1.5",
-            "eslint-import-resolver-node": "0.2.3",
-            "has": "1.0.1",
-            "lodash.cond": "4.5.2",
-            "lodash.endswith": "4.2.1",
-            "lodash.find": "4.6.0",
-            "lodash.findindex": "4.6.0",
-            "minimatch": "3.0.4",
-            "object-assign": "4.1.1",
-            "pkg-dir": "1.0.0",
-            "pkg-up": "1.0.0"
-          },
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "contains-path": {
-              "version": "0.1.0",
-              "bundled": true
-            },
-            "d": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "es5-ext": "0.10.31"
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "doctrine": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
-              }
-            },
-            "es5-ext": {
-              "version": "0.10.31",
-              "bundled": true,
-              "requires": {
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1"
-              }
-            },
-            "es6-iterator": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-symbol": "3.1.1"
-              }
-            },
-            "es6-map": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-iterator": "2.0.1",
-                "es6-set": "0.1.5",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-              }
-            },
-            "es6-set": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31",
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-              }
-            },
-            "es6-symbol": {
-              "version": "3.1.1",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31"
-              }
-            },
-            "eslint-import-resolver-node": {
-              "version": "0.2.3",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.9",
-                "object-assign": "4.1.1",
-                "resolve": "1.4.0"
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "event-emitter": {
-              "version": "0.3.5",
-              "bundled": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.31"
-              }
-            },
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "function-bind": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "has": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "function-bind": "1.1.1"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "lodash.cond": {
-              "version": "4.5.2",
-              "bundled": true
-            },
-            "lodash.endswith": {
-              "version": "4.2.1",
-              "bundled": true
-            },
-            "lodash.find": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.findindex": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "1.1.2"
-              }
-            },
-            "pkg-up": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "1.1.2"
-              }
-            },
-            "resolve": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "path-parse": "1.0.5"
-              }
-            }
-          }
-        },
-        "eslint-plugin-jsx-a11y": {
-          "version": "1.5.5",
-          "bundled": true,
-          "requires": {
-            "damerau-levenshtein": "1.0.4",
-            "jsx-ast-utils": "1.4.1",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "damerau-levenshtein": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "jsx-ast-utils": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-plugin-react": {
-          "version": "5.2.2",
-          "bundled": true,
-          "requires": {
-            "doctrine": "1.5.0",
-            "jsx-ast-utils": "1.4.1"
-          },
-          "dependencies": {
-            "doctrine": {
-              "version": "1.5.0",
-              "bundled": true,
-              "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "jsx-ast-utils": {
-              "version": "1.4.1",
-              "bundled": true
-            }
-          }
-        },
-        "esprima": {
-          "bundled": true
-        },
-        "esutils": {
-          "bundled": true
-        },
-        "etag": {
-          "version": "1.8.1",
-          "bundled": true
-        },
-        "expand-brackets": {
-          "bundled": true
-        },
-        "expand-range": {
-          "bundled": true
-        },
-        "express": {
-          "version": "4.16.1",
-          "bundled": true,
-          "requires": {
-            "accepts": "1.3.4",
-            "array-flatten": "1.1.1",
-            "body-parser": "1.18.2",
-            "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
-            "cookie": "0.3.1",
-            "cookie-signature": "1.0.6",
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "finalhandler": "1.1.0",
-            "fresh": "0.5.2",
-            "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.2",
-            "qs": "6.5.1",
-            "range-parser": "1.2.0",
-            "safe-buffer": "5.1.1",
-            "send": "0.16.1",
-            "serve-static": "1.13.1",
-            "setprototypeof": "1.1.0",
-            "statuses": "1.3.1",
-            "type-is": "1.6.15",
-            "utils-merge": "1.0.1",
-            "vary": "1.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            }
-          }
-        },
-        "extend": {
-          "bundled": true
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "extglob": {
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "faye-websocket": {
-          "version": "0.10.0",
-          "bundled": true,
-          "requires": {
-            "websocket-driver": "0.6.5"
-          }
-        },
-        "fetch-mock": {
-          "version": "5.13.0",
-          "bundled": true,
-          "requires": {
-            "glob-to-regexp": "0.3.0",
-            "node-fetch": "1.7.3",
-            "path-to-regexp": "1.7.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "path-to-regexp": {
-              "version": "1.7.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "0.0.1"
-              }
-            }
-          }
-        },
-        "filename-regex": {
-          "bundled": true
-        },
-        "fill-range": {
-          "bundled": true
-        },
-        "finalhandler": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "find-up": {
-          "bundled": true
-        },
-        "first-chunk-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "flow-bin": {
-          "version": "0.49.1",
-          "bundled": true
-        },
-        "for-in": {
-          "bundled": true
-        },
-        "for-own": {
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "forwarded": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "fresh": {
-          "version": "0.5.2",
-          "bundled": true
-        },
-        "fs-readdir-recursive": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "bundled": true
-        },
-        "fsevents": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "nan": "2.7.0",
-            "node-pre-gyp": "0.6.36"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.2.9"
-              }
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "2.10.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "0.4.2",
-                "concat-map": "0.0.1"
-              }
-            },
-            "buffer-shims": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true,
-              "optional": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "optional": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aproba": "1.1.1",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "bundled": true
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.0"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "optional": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.0.2",
-                "json-schema": "0.2.3",
-                "verror": "1.3.6"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.27.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "node-pre-gyp": {
-              "version": "0.6.36",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.0",
-                "rc": "1.2.1",
-                "request": "2.81.0",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.0"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1.1.0",
-                "osenv": "0.1.4"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true
-            },
-            "qs": {
-              "version": "6.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "bundled": true,
-              "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "1.0.1",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.0.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "sshpk": {
-              "version": "1.13.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true,
-              "optional": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.2.9",
-                "rimraf": "2.6.1",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "verror": {
-              "version": "1.3.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "extsprintf": "1.0.2"
-              }
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "string-width": "1.0.2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "get-comments": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "get-port": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "git-up": {
-          "version": "2.0.8",
-          "bundled": true,
-          "requires": {
-            "is-ssh": "1.3.0",
-            "parse-url": "1.3.11"
-          }
-        },
-        "git-url-parse": {
-          "version": "6.2.2",
-          "bundled": true,
-          "requires": {
-            "git-up": "2.0.8"
-          }
-        },
-        "github-slugger": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "emoji-regex": "6.1.1"
-          }
-        },
-        "glob": {
-          "bundled": true
-        },
-        "glob-base": {
-          "bundled": true
-        },
-        "glob-parent": {
-          "bundled": true
-        },
-        "glob-stream": {
-          "version": "5.3.5",
-          "bundled": true,
-          "requires": {
-            "ordered-read-streams": "0.3.0",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
-          }
-        },
-        "glob-to-regexp": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "globals": {
-          "bundled": true
-        },
-        "globals-docs": {
-          "version": "2.3.0",
-          "bundled": true
-        },
-        "graceful-fs": {
-          "bundled": true
-        },
-        "gulp-sourcemaps": {
-          "version": "1.6.0",
-          "bundled": true,
-          "requires": {
-            "strip-bom": "2.0.0",
-            "vinyl": "1.2.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            },
-            "vinyl": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "clone": "1.0.2",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
-              }
-            }
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.2.3",
-            "har-schema": "2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.2.3",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "json-schema-traverse": "0.3.1",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "has-ansi": {
-          "bundled": true
-        },
-        "hash-base": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "hasprop": {
-          "version": "0.0.4",
-          "bundled": true,
-          "requires": {
-            "tape": "3.6.1"
-          },
-          "dependencies": {
-            "defined": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-              "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
-            },
-            "glob": {
-              "version": "3.2.11",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-              "requires": {
-                "inherits": "2.0.3",
-                "minimatch": "0.3.0"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "minimatch": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-              "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
-              }
-            },
-            "tape": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/tape/-/tape-3.6.1.tgz",
-              "integrity": "sha1-SJPdU+KApfWMDOswwsDrs7zVHh8=",
-              "requires": {
-                "deep-equal": "0.2.2",
-                "defined": "0.0.0",
-                "glob": "3.2.11",
-                "inherits": "2.0.3",
-                "object-inspect": "0.4.0",
-                "resumer": "0.0.0",
-                "through": "2.3.8"
-              }
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-            }
-          }
-        },
-        "hast-util-is-element": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "hast-util-sanitize": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "hast-util-to-html": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "ccount": "1.0.2",
-            "comma-separated-tokens": "1.0.4",
-            "hast-util-is-element": "1.0.0",
-            "hast-util-whitespace": "1.0.0",
-            "html-void-elements": "1.0.2",
-            "kebab-case": "1.0.0",
-            "property-information": "3.2.0",
-            "space-separated-tokens": "1.1.1",
-            "stringify-entities": "1.3.1",
-            "unist-util-is": "2.1.1"
-          }
-        },
-        "hast-util-whitespace": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
-          }
-        },
-        "highlight.js": {
-          "version": "9.12.0",
-          "bundled": true
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "home-or-tmp": {
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "bundled": true
-        },
-        "html-void-elements": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "htmlparser2": {
-          "version": "3.9.2",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.4.1",
-            "domutils": "1.5.1",
-            "entities": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "bundled": true,
-          "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": "1.3.1"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "inflight": {
-          "bundled": true
-        },
-        "inherits": {
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true
-        },
-        "invariant": {
-          "bundled": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ipaddr.js": {
-          "version": "1.5.2",
-          "bundled": true
-        },
-        "is-absolute": {
-          "version": "0.2.6",
-          "bundled": true,
-          "requires": {
-            "is-relative": "0.2.1",
-            "is-windows": "0.2.0"
-          }
-        },
-        "is-alphabetical": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-alphanumeric": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-alphanumerical": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "is-alphabetical": "1.0.1",
-            "is-decimal": "1.0.1"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "is-binary-path": {
-          "bundled": true
-        },
-        "is-buffer": {
-          "bundled": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-decimal": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-dotfile": {
-          "bundled": true
-        },
-        "is-equal-shallow": {
-          "bundled": true
-        },
-        "is-extendable": {
-          "bundled": true
-        },
-        "is-extglob": {
-          "bundled": true
-        },
-        "is-finite": {
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "bundled": true
-        },
-        "is-glob": {
-          "bundled": true
-        },
-        "is-hexadecimal": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-number": {
-          "bundled": true
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-posix-bracket": {
-          "bundled": true
-        },
-        "is-primitive": {
-          "bundled": true
-        },
-        "is-relative": {
-          "version": "0.2.1",
-          "bundled": true,
-          "requires": {
-            "is-unc-path": "0.1.2"
-          }
-        },
-        "is-ssh": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "protocols": "1.4.5"
-          }
-        },
-        "is-stream": {
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-unc-path": {
-          "version": "0.1.2",
-          "bundled": true,
-          "requires": {
-            "unc-path-regex": "0.1.2"
-          }
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "is-valid-glob": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "is-whitespace-character": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-windows": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "is-word-character": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "isarray": {
-          "bundled": true
-        },
-        "isobject": {
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          },
-          "dependencies": {
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "bundled": true
-        },
-        "js-yaml": {
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsesc": {
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "json5": {
-          "bundled": true
-        },
-        "jsonify": {
-          "bundled": true
-        },
-        "jsonparse": {
-          "bundled": true
-        },
-        "jsontokens": {
-          "version": "0.7.6",
-          "bundled": true,
-          "requires": {
-            "asn1.js": "4.9.1",
-            "base64url": "2.0.0",
-            "crypto": "0.0.3",
-            "elliptic": "6.4.0",
-            "key-encoder": "1.1.6",
-            "validator": "7.2.0"
-          },
-          "dependencies": {
-            "asn1.js": {
-              "version": "4.9.1",
-              "bundled": true,
-              "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
-              }
-            },
-            "base64url": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "bn.js": {
-              "version": "4.11.8",
-              "bundled": true
-            },
-            "brorand": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "hash.js": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "key-encoder": {
-              "version": "1.1.6",
-              "bundled": true,
-              "requires": {
-                "asn1.js": "2.2.1",
-                "bn.js": "3.3.0",
-                "elliptic": "5.2.1"
-              },
-              "dependencies": {
-                "asn1.js": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "bn.js": "2.2.0",
-                    "inherits": "2.0.3",
-                    "minimalistic-assert": "1.0.0"
-                  },
-                  "dependencies": {
-                    "bn.js": {
-                      "version": "2.2.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "bn.js": {
-                  "version": "3.3.0",
-                  "bundled": true
-                },
-                "elliptic": {
-                  "version": "5.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "bn.js": "3.3.0",
-                    "brorand": "1.1.0",
-                    "hash.js": "1.1.3",
-                    "inherits": "2.0.3"
-                  }
-                }
-              }
-            },
-            "minimalistic-assert": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "kebab-case": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "kind-of": {
-          "bundled": true
-        },
-        "lazystream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
-        },
-        "livereload-js": {
-          "version": "2.2.2",
-          "bundled": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "parse-json": "2.2.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "lodash": {
-          "bundled": true
-        },
-        "lodash.assignin": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "lodash.bind": {
-          "version": "4.2.1",
-          "bundled": true
-        },
-        "lodash.defaults": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "lodash.filter": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.flatten": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lodash.foreach": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.isequal": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.map": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.merge": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.pick": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lodash.reduce": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.reject": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.some": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "longest-streak": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "loose-envify": {
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "bundled": true
-        },
-        "map-cache": {
-          "version": "0.2.2",
-          "bundled": true
-        },
-        "markdown-escapes": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "markdown-table": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "md5.js": {
-          "version": "1.3.4",
-          "bundled": true,
-          "requires": {
-            "hash-base": "3.0.4",
-            "inherits": "2.0.3"
-          },
-          "dependencies": {
-            "hash-base": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "mdast-util-compact": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "unist-util-modify-children": "1.1.1",
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "mdast-util-definitions": {
-          "version": "1.2.2",
-          "bundled": true,
-          "requires": {
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "mdast-util-inject": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "mdast-util-to-string": "1.0.4"
-          }
-        },
-        "mdast-util-to-hast": {
-          "version": "2.4.2",
-          "bundled": true,
-          "requires": {
-            "collapse-white-space": "1.0.3",
-            "detab": "2.0.1",
-            "mdast-util-definitions": "1.2.2",
-            "normalize-uri": "1.1.0",
-            "trim": "0.0.1",
-            "trim-lines": "1.1.0",
-            "unist-builder": "1.0.2",
-            "unist-util-generated": "1.1.1",
-            "unist-util-position": "3.0.0",
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "mdast-util-to-string": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "mdast-util-toc": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "github-slugger": "1.1.3",
-            "mdast-util-to-string": "1.0.4",
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "media-typer": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "merge-descriptors": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "merge-stream": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "methods": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "micromatch": {
-          "bundled": true
-        },
-        "mime": {
-          "bundled": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "minimatch": {
-          "bundled": true
-        },
-        "minimist": {
-          "bundled": true
-        },
-        "mkdirp": {
-          "bundled": true
-        },
-        "ms": {
-          "bundled": true
-        },
-        "nan": {
-          "version": "2.7.0",
-          "bundled": true,
-          "optional": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          },
-          "dependencies": {
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "normalize-path": {
-          "bundled": true
-        },
-        "normalize-uri": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "nth-check": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "boolbase": "1.0.0"
-          }
-        },
-        "number-is-nan": {
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "bundled": true
-        },
-        "object-inspect": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "object.omit": {
-          "bundled": true
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "ee-first": "1.1.1"
-          }
-        },
-        "once": {
-          "bundled": true
-        },
-        "opn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "ordered-read-streams": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "os-homedir": {
-          "bundled": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "os-tmpdir": {
-          "bundled": true
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            }
-          }
-        },
-        "parents": {
-          "bundled": true
-        },
-        "parse-entities": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "character-entities": "1.2.1",
-            "character-entities-legacy": "1.1.1",
-            "character-reference-invalid": "1.1.1",
-            "is-alphanumerical": "1.0.1",
-            "is-decimal": "1.0.1",
-            "is-hexadecimal": "1.0.1"
-          }
-        },
-        "parse-filepath": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "is-absolute": "0.2.6",
-            "map-cache": "0.2.2",
-            "path-root": "0.1.1"
-          }
-        },
-        "parse-git-config": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "ini": "1.3.4"
-          }
-        },
-        "parse-glob": {
-          "bundled": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "parse-url": {
-          "version": "1.3.11",
-          "bundled": true,
-          "requires": {
-            "is-ssh": "1.3.0",
-            "protocols": "1.4.5"
-          }
-        },
-        "parseurl": {
-          "version": "1.3.2",
-          "bundled": true
-        },
-        "path-exists": {
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "path-platform": {
-          "bundled": true
-        },
-        "path-root": {
-          "version": "0.1.1",
-          "bundled": true,
-          "requires": {
-            "path-root-regex": "0.1.2"
-          }
-        },
-        "path-root-regex": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "path-to-regexp": {
-          "version": "0.1.7",
-          "bundled": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pify": {
-          "bundled": true
-        },
-        "pinkie": {
-          "bundled": true
-        },
-        "pinkie-promise": {
-          "bundled": true
-        },
-        "preserve": {
-          "bundled": true
-        },
-        "private": {
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "property-information": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "protocols": {
-          "version": "1.4.5",
-          "bundled": true
-        },
-        "proxy-addr": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "forwarded": "0.1.2",
-            "ipaddr.js": "1.5.2"
-          }
-        },
-        "qs": {
-          "bundled": true
-        },
-        "query-string": {
-          "version": "4.3.4",
-          "bundled": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "strict-uri-encode": {
-              "version": "1.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "randomatic": {
-          "bundled": true
-        },
-        "range-parser": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "raw-body": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "bytes": "1.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "read-pkg": "2.0.0"
-          }
-        },
-        "readable-stream": {
-          "bundled": true
-        },
-        "readdirp": {
-          "bundled": true
-        },
-        "regenerator-runtime": {
-          "bundled": true
-        },
-        "regex-cache": {
-          "bundled": true
-        },
-        "remark": {
-          "version": "8.0.0",
-          "bundled": true,
-          "requires": {
-            "remark-parse": "4.0.0",
-            "remark-stringify": "4.0.0",
-            "unified": "6.1.5"
-          }
-        },
-        "remark-html": {
-          "version": "6.0.1",
-          "bundled": true,
-          "requires": {
-            "hast-util-sanitize": "1.1.1",
-            "hast-util-to-html": "3.1.0",
-            "mdast-util-to-hast": "2.4.2"
-          }
-        },
-        "remark-parse": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "collapse-white-space": "1.0.3",
-            "is-alphabetical": "1.0.1",
-            "is-decimal": "1.0.1",
-            "is-whitespace-character": "1.0.1",
-            "is-word-character": "1.0.1",
-            "markdown-escapes": "1.0.1",
-            "parse-entities": "1.1.1",
-            "state-toggle": "1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "1.1.0",
-            "unherit": "1.1.0",
-            "unist-util-remove-position": "1.1.1",
-            "vfile-location": "2.0.2"
-          }
-        },
-        "remark-slug": {
-          "version": "4.2.3",
-          "bundled": true,
-          "requires": {
-            "github-slugger": "1.1.3",
-            "mdast-util-to-string": "1.0.4",
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "remark-stringify": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "ccount": "1.0.2",
-            "is-alphanumeric": "1.0.0",
-            "is-decimal": "1.0.1",
-            "is-whitespace-character": "1.0.1",
-            "longest-streak": "2.0.1",
-            "markdown-escapes": "1.0.1",
-            "markdown-table": "1.1.1",
-            "mdast-util-compact": "1.0.1",
-            "parse-entities": "1.1.1",
-            "state-toggle": "1.0.0",
-            "stringify-entities": "1.3.1",
-            "unherit": "1.1.0"
-          }
-        },
-        "remark-toc": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "mdast-util-toc": "2.0.1",
-            "remark-slug": "4.2.3"
-          }
-        },
-        "remote-origin-url": {
-          "version": "0.4.0",
-          "bundled": true,
-          "requires": {
-            "parse-git-config": "0.2.0"
-          }
-        },
-        "remove-trailing-separator": {
-          "bundled": true
-        },
-        "repeat-element": {
-          "bundled": true
-        },
-        "repeat-string": {
-          "bundled": true
-        },
-        "repeating": {
-          "bundled": true
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            }
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "resolve": {
-          "bundled": true
-        },
-        "resumer": {
-          "version": "0.0.0",
-          "bundled": true,
-          "requires": {
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "safe-json-parse": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "schema-inspector": {
-          "version": "1.6.8",
-          "bundled": true,
-          "requires": {
-            "async": "1.5.2"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "bundled": true
-            }
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "bundled": true
-        },
-        "send": {
-          "version": "0.16.1",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "1.6.2",
-            "mime": "1.4.1",
-            "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "mime": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
-            "send": "0.16.1"
-          }
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "set-immediate-shim": {
-          "bundled": true
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "shelljs": {
-          "bundled": true
-        },
-        "sigmund": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "slash": {
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "bundled": true
-        },
-        "source-map-support": {
-          "bundled": true
-        },
-        "space-separated-tokens": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "trim": "0.0.1"
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "bundled": true
-        },
-        "sprintf-js": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "state-toggle": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "stream-array": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "stream-combiner2": {
-          "bundled": true
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "string-template": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "string-width": {
-          "bundled": true
-        },
-        "string_decoder": {
-          "bundled": true
-        },
-        "stringify-entities": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "character-entities-html4": "1.1.1",
-            "character-entities-legacy": "1.1.1",
-            "is-alphanumerical": "1.0.1",
-            "is-hexadecimal": "1.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "strip-ansi": {
-          "bundled": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "strip-bom-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "first-chunk-stream": "1.0.0",
-            "strip-bom": "2.0.0"
-          },
-          "dependencies": {
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            }
-          }
-        },
-        "strip-json-comments": {
-          "bundled": true
-        },
-        "subarg": {
-          "bundled": true,
-          "dependencies": {
-            "minimist": {
-              "bundled": true
-            }
-          }
-        },
-        "supports-color": {
-          "bundled": true
-        },
-        "tape": {
-          "version": "4.8.0",
-          "bundled": true,
-          "requires": {
-            "deep-equal": "1.0.1",
-            "defined": "1.0.0",
-            "for-each": "0.3.2",
-            "function-bind": "1.1.1",
-            "glob": "7.1.2",
-            "has": "1.0.1",
-            "inherits": "2.0.3",
-            "minimist": "1.2.0",
-            "object-inspect": "1.3.0",
-            "resolve": "1.4.0",
-            "resumer": "0.0.0",
-            "string.prototype.trim": "1.1.2",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "deep-equal": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "define-properties": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
-              }
-            },
-            "defined": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "es-abstract": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.1",
-                "is-callable": "1.1.3",
-                "is-regex": "1.0.4"
-              }
-            },
-            "es-to-primitive": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "is-callable": "1.1.3",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
-              }
-            },
-            "for-each": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "is-function": "1.0.1"
-              }
-            },
-            "foreach": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "function-bind": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "has": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "function-bind": "1.1.1"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "is-callable": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "is-date-object": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "is-function": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "is-regex": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "has": "1.0.1"
-              }
-            },
-            "is-symbol": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "object-inspect": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "object-keys": {
-              "version": "1.0.11",
-              "bundled": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "resolve": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "path-parse": "1.0.5"
-              }
-            },
-            "resumer": {
-              "version": "0.0.0",
-              "bundled": true,
-              "requires": {
-                "through": "2.3.8"
-              }
-            },
-            "string.prototype.trim": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.9.0",
-                "function-bind": "1.1.1"
-              }
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "tape-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "is-promise": "2.1.0",
-            "onetime": "2.0.1"
-          },
-          "dependencies": {
-            "is-promise": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "mimic-fn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "onetime": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "mimic-fn": "1.1.0"
-              }
-            }
-          }
-        },
-        "through": {
-          "bundled": true
-        },
-        "through2": {
-          "bundled": true
-        },
-        "through2-filter": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "tiny-lr": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "body": "5.1.0",
-            "faye-websocket": "0.10.0",
-            "livereload-js": "2.2.2"
-          }
-        },
-        "to-absolute-glob": {
-          "version": "0.1.1",
-          "bundled": true,
-          "requires": {
-            "extend-shallow": "2.0.1"
-          }
-        },
-        "to-fast-properties": {
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            }
-          }
-        },
-        "trim": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "trim-lines": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "trim-right": {
-          "bundled": true
-        },
-        "trim-trailing-lines": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "trough": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-is": {
-          "version": "1.6.15",
-          "bundled": true,
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "2.1.17"
-          }
-        },
-        "typedarray": {
-          "bundled": true
-        },
-        "unc-path-regex": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "unherit": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "unified": {
-          "version": "6.1.5",
-          "bundled": true,
-          "requires": {
-            "bail": "1.0.2",
-            "is-plain-obj": "1.1.0",
-            "trough": "1.0.1",
-            "vfile": "2.2.0",
-            "x-is-function": "1.0.4",
-            "x-is-string": "0.1.0"
-          }
-        },
-        "unique-stream": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "through2-filter": "2.0.0"
-          }
-        },
-        "unist-builder": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "unist-util-generated": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "unist-util-is": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "unist-util-modify-children": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "array-iterate": "1.1.1"
-          }
-        },
-        "unist-util-position": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "unist-util-remove-position": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "unist-util-visit": "1.1.3"
-          }
-        },
-        "unist-util-stringify-position": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "unist-util-visit": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "bundled": true
-        },
-        "utils-merge": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "v8flags": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "user-home": "1.1.1"
-          }
-        },
-        "vali-date": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        },
-        "validator": {
-          "version": "7.2.0",
-          "bundled": true
-        },
-        "vary": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "vfile": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "replace-ext": "1.0.0",
-            "unist-util-stringify-position": "1.1.1"
-          }
-        },
-        "vfile-location": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "vfile-reporter": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "unist-util-stringify-position": "1.1.1",
-            "vfile-statistics": "1.1.0"
-          }
-        },
-        "vfile-sort": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "vfile-statistics": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "vinyl": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "replace-ext": "1.0.0"
-          }
-        },
-        "vinyl-fs": {
-          "version": "2.4.4",
-          "bundled": true,
-          "requires": {
-            "duplexify": "3.5.1",
-            "glob-stream": "5.3.5",
-            "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            },
-            "vinyl": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "clone": "1.0.2",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
-              }
-            }
-          }
-        },
-        "websocket-driver": {
-          "version": "0.6.5",
-          "bundled": true,
-          "requires": {
-            "websocket-extensions": "0.1.1"
-          }
-        },
-        "websocket-extensions": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "wrappy": {
-          "bundled": true
-        },
-        "x-is-function": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "x-is-string": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "xtend": {
-          "bundled": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "bundled": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          },
-          "dependencies": {
-            "load-json-file": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "parse-json": "2.2.0",
-                "strip-bom": "2.0.0"
-              }
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "read-pkg": "1.1.0"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "camelcase": "3.0.0"
-          }
-        },
-        "zone-file": {
-          "version": "0.2.2",
-          "bundled": true
-        }
+      }
+    },
+    "blockstack-storage": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/blockstack-storage/-/blockstack-storage-0.2.11.tgz",
+      "integrity": "sha512-U/dPDYz7PcZVy3eg0Dr5QKaxdCd6qqK2P2BKo7EQ4v6fy44+lHreGmK+HM/Eo/AmK9dhvFa4vk7HsFgWnFYmIw==",
+      "requires": {
+        "ajv": "4.11.8",
+        "bitcoinjs-lib": "2.3.0",
+        "elliptic": "6.4.0",
+        "isomorphic-fetch": "2.2.1",
+        "jsontokens": "0.7.6",
+        "uuid": "3.1.0"
       }
     },
     "bluebird": {
@@ -9044,8 +1252,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.18.2",
@@ -9068,8 +1275,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boom": {
       "version": "4.3.1",
@@ -9107,13 +1313,12 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browserify-aes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz",
-      "integrity": "sha512-W2bIMLYoZ9oow7TyePpMJk9l9LY7O3R61a/68bVCDOtnJynnwe3ZeW2IzzSkrQnPKNdJrxVDn3ALZNisSBwb7g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
@@ -9130,7 +1335,7 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.0",
+        "browserify-aes": "1.1.1",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -9186,8 +1391,25 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000747",
-        "electron-to-chromium": "1.3.26"
+        "caniuse-db": "1.0.30000748",
+        "electron-to-chromium": "1.3.27"
+      }
+    },
+    "bs58": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
+      "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
+      "requires": {
+        "base-x": "1.1.0"
+      }
+    },
+    "bs58check": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
+      "integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
+      "requires": {
+        "bs58": "3.1.0",
+        "create-hash": "1.1.3"
       }
     },
     "buffer": {
@@ -9200,6 +1422,21 @@
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-compare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.1.1.tgz",
+      "integrity": "sha1-W+e+hTr4kZjR9N3AkNHWakiu9ZY="
+    },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
+    },
+    "buffer-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -9270,21 +1507,21 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000747",
+        "caniuse-db": "1.0.30000748",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000747",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000747.tgz",
-      "integrity": "sha1-j1vWweXmBFpNTmxqOlktGeGotRQ=",
+      "version": "1.0.30000748",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000748.tgz",
+      "integrity": "sha1-eF2e381kW/eVxv887TPEXVgMSKA=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000747",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000747.tgz",
-      "integrity": "sha1-2obnjhLQZBq+6u5uzVXYG9m9O10=",
+      "version": "1.0.30000748",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000748.tgz",
+      "integrity": "sha1-RMjW2lKtZaXXudyk7+vQvdmCugk=",
       "dev": true
     },
     "caseless": {
@@ -9320,6 +1557,29 @@
         "has-ansi": "2.0.0",
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
+      }
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.0",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       }
     },
     "chokidar": {
@@ -9360,7 +1620,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -9457,7 +1716,7 @@
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "1.5.0"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -9629,9 +1888,9 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.1.1.tgz",
-      "integrity": "sha512-qcjV9uj5PFuKo9GDr0xYAZ3DwFA3ugwDcfbLHfiDrvnUx66Z7C4r00/ds856GaGb2cGHqLTwrGxwfvW+lgAQew==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-eZERim02YjJcepLjrToQMapOoRLfiXewJi9zJON6xXNNJSUhkGzL1L/yFjOufS0KxsnWUzc2szg9t8ZaZKJXAg==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
@@ -9644,6 +1903,20 @@
         "node-dir": "0.1.17"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
@@ -9654,6 +1927,15 @@
             "emojis-list": "2.1.0",
             "json5": "0.5.1",
             "object-assign": "4.1.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -9698,7 +1980,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
@@ -9710,7 +1991,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "create-hash": "1.1.3",
@@ -9727,6 +2007,17 @@
       "requires": {
         "lru-cache": "4.1.1",
         "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
       }
     },
     "cryptiles": {
@@ -9746,6 +2037,11 @@
           }
         }
       }
+    },
+    "crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
+      "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
     },
     "crypto-browserify": {
       "version": "3.11.1",
@@ -9797,24 +2093,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
       "requires": {
         "boolbase": "1.0.0",
         "css-what": "2.1.0",
         "domutils": "1.5.1",
         "nth-check": "1.0.1"
-      },
-      "dependencies": {
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
-          }
-        }
       }
     },
     "css-selector-tokenizer": {
@@ -9844,8 +2127,7 @@
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-      "dev": true
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
     "cssesc": {
       "version": "0.1.0",
@@ -9891,6 +2173,14 @@
         "postcss-unique-selectors": "2.0.2",
         "postcss-value-parser": "3.3.0",
         "postcss-zindex": "2.2.0"
+      },
+      "dependencies": {
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        }
       }
     },
     "csso": {
@@ -9918,6 +2208,11 @@
       "requires": {
         "array-find-index": "1.0.2"
       }
+    },
+    "custom-protocol-detection-blockstack": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/custom-protocol-detection-blockstack/-/custom-protocol-detection-blockstack-1.1.3.tgz",
+      "integrity": "sha512-iGwXqKU60VAzfjLF/amcJKQYMLeMlXAlzkZttakOQA7IjZw2WFSYAmn9a13d0LOBTzdVpbHnF+zZArNC9csiZw=="
     },
     "d": {
       "version": "1.0.0",
@@ -9961,6 +2256,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -9968,10 +2268,9 @@
       "dev": true
     },
     "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
     },
     "del": {
       "version": "2.2.2",
@@ -10071,7 +2370,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.1.3",
         "entities": "1.1.1"
@@ -10080,8 +2378,7 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
@@ -10094,23 +2391,20 @@
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.3.0"
       }
     },
     "domutils": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
-      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
-      "dev": true,
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
@@ -10129,6 +2423,14 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecurve": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.5.tgz",
+      "integrity": "sha1-0Ujo/lCmdPmDu1uuCdoOoj4QU14=",
+      "requires": {
+        "bigi": "1.4.2"
       }
     },
     "editorconfig": {
@@ -10168,16 +2470,15 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.26",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz",
-      "integrity": "sha1-mWQnKUhhp02cfIK5Jg6jAejALWY=",
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
@@ -10199,6 +2500,14 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "enhanced-resolve": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
@@ -10214,8 +2523,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "errno": {
       "version": "0.1.4",
@@ -10277,6 +2585,11 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
     },
     "es6-set": {
       "version": "0.1.5",
@@ -10379,6 +2692,29 @@
         "user-home": "2.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -10624,6 +2960,17 @@
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0",
         "webpack-sources": "1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -10684,9 +3031,9 @@
       "dev": true
     },
     "filesize": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz",
-      "integrity": "sha1-/I+iPdtO+eXgq24eZPZ5okpWdh8=",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
+      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
       "dev": true
     },
     "fill-range": {
@@ -11610,6 +3957,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -11618,14 +3973,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -11814,16 +4161,12 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
         "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "minimatch": "0.3.0"
       }
     },
     "glob-base": {
@@ -11897,6 +4240,31 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "globule": {
@@ -11907,6 +4275,29 @@
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -11935,6 +4326,19 @@
       "requires": {
         "ajv": "5.2.3",
         "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "has": {
@@ -11969,7 +4373,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -11984,10 +4387,17 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
+      }
+    },
+    "hasprop": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/hasprop/-/hasprop-0.0.4.tgz",
+      "integrity": "sha1-mbJGuNF7l4NwY0ZdVRmB1j3J5ME=",
+      "requires": {
+        "tape": "3.6.1"
       }
     },
     "hawk": {
@@ -12011,7 +4421,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "1.1.3",
         "minimalistic-assert": "1.0.0",
@@ -12098,11 +4507,10 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.3.0",
         "domhandler": "2.4.1",
-        "domutils": "1.6.2",
+        "domutils": "1.5.1",
         "entities": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
@@ -12180,8 +4588,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -12538,6 +4945,11 @@
         "tryit": "1.0.3"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-svg": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
@@ -12571,6 +4983,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -12676,6 +5097,19 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsontokens": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.6.tgz",
+      "integrity": "sha1-4j3XXqELECjqnV11EtyyScWY1K0=",
+      "requires": {
+        "asn1.js": "4.9.1",
+        "base64url": "2.0.0",
+        "crypto": "0.0.3",
+        "elliptic": "6.4.0",
+        "key-encoder": "1.1.6",
+        "validator": "7.2.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -12685,6 +5119,51 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "key-encoder": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-1.1.6.tgz",
+      "integrity": "sha1-ATVYLNPQp+t5LZTso4e2gejloq0=",
+      "requires": {
+        "asn1.js": "2.2.1",
+        "bn.js": "3.3.0",
+        "elliptic": "5.2.1"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
+          "integrity": "sha1-yLpN1o6EQxKIEmIwyyBFvfqfv+E=",
+          "requires": {
+            "bn.js": "2.2.0",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+              "integrity": "sha1-EhYrwq5x/EClYmwzQ486h1zTdiU="
+            }
+          }
+        },
+        "bn.js": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-3.3.0.tgz",
+          "integrity": "sha1-ETjld4if3Je72rUYRPIZDfwK49c="
+        },
+        "elliptic": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
+          "integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
+          "requires": {
+            "bn.js": "3.3.0",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.3",
+            "inherits": "2.0.3"
+          }
+        }
       }
     },
     "kind-of": {
@@ -12766,6 +5245,16 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -12777,16 +5266,66 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
     "lodash.mergewith": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.tail": {
       "version": "4.1.1",
@@ -12839,13 +5378,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "macaddress": {
       "version": "0.2.8",
@@ -13007,21 +5542,20 @@
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-      "dev": true
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
       }
     },
     "minimist": {
@@ -13113,6 +5647,26 @@
       "dev": true,
       "requires": {
         "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-gyp": {
@@ -13135,6 +5689,27 @@
         "which": "1.3.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -13204,6 +5779,29 @@
         "request": "2.83.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "nopt": {
@@ -13267,7 +5865,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
       "requires": {
         "boolbase": "1.0.0"
       }
@@ -13298,6 +5895,11 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.2.0.tgz",
       "integrity": "sha512-smRWXzkvxw72VquyZ0wggySl7PFUtoDhvhpdwgESXxUrH7vVhhp9asfup1+rVLrhsl7L45Ee1Q/l5R2Ul4MwUg==",
       "dev": true
+    },
+    "object-inspect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
     },
     "object.omit": {
       "version": "2.0.1",
@@ -13505,7 +6107,7 @@
       "dev": true,
       "requires": {
         "asn1.js": "4.9.1",
-        "browserify-aes": "1.1.0",
+        "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -14303,6 +6905,14 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -14349,9 +6959,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
@@ -14363,7 +6973,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
       "requires": {
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
@@ -14426,7 +7035,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -14492,6 +7100,17 @@
         "minimatch": "3.0.4",
         "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "readline2": {
@@ -14818,6 +7437,14 @@
         "onetime": "1.1.0"
       }
     },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -14833,13 +7460,35 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
@@ -14874,6 +7523,29 @@
         "lodash": "4.17.4",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "sass-loader": {
@@ -14888,6 +7560,14 @@
         "pify": "3.0.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -14901,6 +7581,14 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "schema-inspector": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/schema-inspector/-/schema-inspector-1.6.8.tgz",
+      "integrity": "sha1-ueU5g8xV/y29e2Xj2+CF2dEoXyo=",
+      "requires": {
+        "async": "1.5.2"
+      }
+    },
     "schema-utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
@@ -14908,6 +7596,20 @@
       "dev": true,
       "requires": {
         "ajv": "5.2.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "scss-tokenizer": {
@@ -14984,7 +7686,6 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -15020,13 +7721,37 @@
         "glob": "7.1.2",
         "interpret": "1.0.4",
         "rechoir": "0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -15112,10 +7837,9 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -15178,8 +7902,15 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "string-length": {
       "version": "1.0.1",
@@ -15198,14 +7929,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -15277,16 +8000,6 @@
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -15326,6 +8039,20 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "tape": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-3.6.1.tgz",
+      "integrity": "sha1-SJPdU+KApfWMDOswwsDrs7zVHh8=",
+      "requires": {
+        "deep-equal": "0.2.2",
+        "defined": "0.0.0",
+        "glob": "3.2.11",
+        "inherits": "2.0.3",
+        "object-inspect": "0.4.0",
+        "resumer": "0.0.0",
+        "through": "2.3.8"
+      }
+    },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -15345,8 +8072,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "time-stamp": {
       "version": "2.0.0",
@@ -15450,6 +8176,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typeforce": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.11.5.tgz",
+      "integrity": "sha512-Glwf7h3CW1YaQrLVeNnMg6KumszBe4adBccF4Ukc8J3nkdgapEkpiMdoPTv3APoqMva3mNN4ZFklGaPNvRfiMQ=="
     },
     "uglify-js": {
       "version": "3.1.4",
@@ -15620,6 +8351,11 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "validator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
+      "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -15683,6 +8419,16 @@
         "vue-template-es2015-compiler": "1.6.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -15731,6 +8477,17 @@
         "async": "2.5.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
       }
     },
     "webpack": {
@@ -15762,14 +8519,13 @@
         "yargs": "6.6.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "lodash": "4.17.4"
           }
         },
         "camelcase": {
@@ -15917,7 +8673,7 @@
         "commander": "2.11.0",
         "ejs": "2.5.7",
         "express": "4.16.2",
-        "filesize": "3.5.10",
+        "filesize": "3.5.11",
         "gzip-size": "3.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -15977,6 +8733,11 @@
         }
       }
     },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
     "whet.extend": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
@@ -16002,6 +8763,14 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
         "string-width": "1.0.2"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "1.3.4"
       }
     },
     "window-size": {
@@ -16120,6 +8889,11 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
+    },
+    "zone-file": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/zone-file/-/zone-file-0.2.2.tgz",
+      "integrity": "sha1-RagyJ/mgXJgcH6KK3Wkw85HCKoE="
     }
   }
 }


### PR DESCRIPTION
I was having issues with `npm i` working out of the box. `node` version 8.4, `npm` version 5.3

Updating `package-lock.json` worked; full log of process below:

```sh
⋊> ~/p/o/blockstack-todos on master ◦ node -v                                                                                  11:14:06
v8.4.0
⋊> ~/p/o/blockstack-todos on master ◦ npm -v                                                                                   11:14:10
5.3.0
⋊> ~/p/o/blockstack-todos on master ◦ npm i                                                                                    11:14:14
npm ERR! path /Users/arjun/projects/open-source/blockstack-todos/node_modules/.staging/blockstack-4c8ecf2e/node_modules/JSONStream
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall rename
npm ERR! enoent ENOENT: no such file or directory, rename '/Users/arjun/projects/open-source/blockstack-todos/node_modules/.staging/blockstack-4c8ecf2e/node_modules/JSONStream' -> '/Users/arjun/projects/open-source/blockstack-todos/node_modules/.staging/JSONStream-5bdc092b'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/arjun/.npm/_logs/2017-10-20T15_14_27_646Z-debug.log
⋊> ~/p/o/blockstack-todos on master ◦ rm -rf node_modules/                                                                     11:14:27
⋊> ~/p/o/blockstack-todos on master ◦ npm i                                                                                    11:14:33
npm ERR! path /Users/arjun/projects/open-source/blockstack-todos/node_modules/.staging/blockstack-4c8ecf2e/node_modules/JSONStream
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall rename
npm ERR! enoent ENOENT: no such file or directory, rename '/Users/arjun/projects/open-source/blockstack-todos/node_modules/.staging/blockstack-4c8ecf2e/node_modules/JSONStream' -> '/Users/arjun/projects/open-source/blockstack-todos/node_modules/.staging/JSONStream-5bdc092b'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/arjun/.npm/_logs/2017-10-20T15_14_47_780Z-debug.log
⋊> ~/p/o/blockstack-todos on master ◦ rm package-lock.json                                                                     11:14:47
⋊> ~/p/o/blockstack-todos on master ⨯ rm -rf node_modules/                                                                     11:14:57
⋊> ~/p/o/blockstack-todos on master ⨯ npm i                                                                                    11:15:00
npm WARN deprecated crypto@0.0.3: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

> fsevents@1.1.2 install /Users/arjun/projects/open-source/blockstack-todos/node_modules/fsevents
> node install

[fsevents] Success: "/Users/arjun/projects/open-source/blockstack-todos/node_modules/fsevents/lib/binding/Release/node-v57-darwin-x64/fse.node" already installed
Pass --update-binary to reinstall or --build-from-source to recompile

> node-sass@4.5.3 install /Users/arjun/projects/open-source/blockstack-todos/node_modules/node-sass
> node scripts/install.js

Cached binary found at /Users/arjun/.npm/node-sass/4.5.3/darwin-x64-57_binding.node

> node-sass@4.5.3 postinstall /Users/arjun/projects/open-source/blockstack-todos/node_modules/node-sass
> node scripts/build.js

Binary found at /Users/arjun/projects/open-source/blockstack-todos/node_modules/node-sass/vendor/darwin-x64-57/binding.node
Testing binary
Binary is fine
npm notice created a lockfile as package-lock.json. You should commit this file.
added 1032 packages in 46.482s
```

Re-trying with new `package-lock`.
```sh
⋊> ~/p/o/blockstack-todos on master ⨯ rm -rf node_modules/                                                                     11:17:03
⋊> ~/p/o/blockstack-todos on master ⨯ npm i                                                                                    11:17:11

> fsevents@1.1.2 install /Users/arjun/projects/open-source/blockstack-todos/node_modules/fsevents
> node install

[fsevents] Success: "/Users/arjun/projects/open-source/blockstack-todos/node_modules/fsevents/lib/binding/Release/node-v57-darwin-x64/fse.node" already installed
Pass --update-binary to reinstall or --build-from-source to recompile

> node-sass@4.5.3 install /Users/arjun/projects/open-source/blockstack-todos/node_modules/node-sass
> node scripts/install.js

Cached binary found at /Users/arjun/.npm/node-sass/4.5.3/darwin-x64-57_binding.node

> node-sass@4.5.3 postinstall /Users/arjun/projects/open-source/blockstack-todos/node_modules/node-sass
> node scripts/build.js

Binary found at /Users/arjun/projects/open-source/blockstack-todos/node_modules/node-sass/vendor/darwin-x64-57/binding.node
Testing binary
Binary is fine
added 1032 packages in 22.688s
```