### PR TITLE
upgrade to 0.17 api which enables file encryption by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
-    "blockstack": "0.13.7",
+    "blockstack": "0.17.0",
     "bootstrap-sass": "^3.3.7",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.5",

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -63,8 +63,9 @@ export default {
     todos: {
       handler: function (todos) {
         const blockstack = this.blockstack
-        const encrypt = true
-        return blockstack.putFile(STORAGE_FILE, JSON.stringify(todos), encrypt)
+
+        // encryption is now enabled by default
+        return blockstack.putFile(STORAGE_FILE, JSON.stringify(todos))
       },
       deep: true
     }
@@ -87,8 +88,7 @@ export default {
 
     fetchData () {
       const blockstack = this.blockstack
-      const decrypt = true
-      blockstack.getFile(STORAGE_FILE, decrypt)
+      blockstack.getFile(STORAGE_FILE) // decryption is enabled by default
       .then((todosText) => {
         var todos = JSON.parse(todosText || '[]')
         todos.forEach(function (todo, index) {


### PR DESCRIPTION
This updates the app to use the 0.17.0.

It depends on approval of this pull request https://github.com/blockstack/blockstack.js/pull/399 and shipment of a v0.17.0 release of blockstack.js.

To test this,

in the blockstack.js repo

```
git checkout feature/encrypt-by-default
npm link
```

in blockstack-todos
```
npm link blockstack
npm run start
```

You can then add and remove todo items and observe that the file written to gaia is encrypted on write and decrypted on read.